### PR TITLE
Reset message when it was already defined

### DIFF
--- a/pomodoro.sh
+++ b/pomodoro.sh
@@ -28,6 +28,7 @@ function pomo {
     fi
 
     TITLE="POMODORO TIMER"
+    MESSAGE=""
     ICON="face-cool"
     BEEP="_alarm 400 200"
     TIMER=1500


### PR DESCRIPTION
This PR reset `MESSAGE` variable at each execution.

If a `pomo -s` has already been executed, when we run new `pomo`, the message is the same as before so `Short break over, back to work`.

To do not keep previous message we reset this variable. 