### PR TITLE
Echo the exact time the session would finish

### DIFF
--- a/pomodoro.sh
+++ b/pomodoro.sh
@@ -67,6 +67,7 @@ function pomo {
     fi
 
     echo -e "${RED}TIMER SET FOR $(($TIMER/60)) MINUTES"
+    echo -e "${RED}TIMER SET TILL $(date -v +$(($TIMER/60))M)"
 
     # LINUX users
     if [[ "$(uname)" == "Linux" ]]; then


### PR DESCRIPTION
Before when we run the script,
`pomo -d 45`


We would get,

```
POMODORO in YA TERMINAL
TIMER SET FOR 45 MINUTES
```

Now we would get,

```
POMODORO in YA TERMINAL
TIMER SET FOR 45 MINUTES
TIMER SET TILL Tue Oct  8 17:35:57 EDT 2019
```