### PR TITLE
Update pomodoro.sh

### DIFF
--- a/pomodoro.sh
+++ b/pomodoro.sh
@@ -63,7 +63,7 @@ function pomo {
     if [ -n "$1" ]; then
         MESSAGE="$1"
     elif [ -z "$MESSAGE" ]; then
-        MESSAGE="It's time to take a break"
+        MESSAGE="Time to take a break"
     fi
 
     echo -e "${RED}TIMER SET FOR $(($TIMER/60)) MINUTES"


### PR DESCRIPTION
The message         MESSAGE="It's time to take a break"
gives a bash eval EOF error because it evaluates the ' and can not find a closing coma.
The error happens when evaluating MESSAGE on this line:
eval "(sleep $TIMER && notify-send '$TITLE' '$MESSAGE' --icon=$ICON && $BEEP &)"
A solution is to simply change the message like I've seen it was before.